### PR TITLE
Edited link to code related contributions and documentation related c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ We value all contributions, whether it's through code, documentation, creating d
 
 Here are a few useful resources to help you get started:
 
-- For code contributions, [check out the contribution guide](https://docs.copilotkit.ai/code-contributions/how-to-contribute?ref=github_readme).
-- For documentation-related contributions, [check out the documentation contributions guide](https://docs.copilotkit.ai/code-contributions/how-to-contribute?ref=github_readme).
+- For code contributions, [check out the contribution guide](https://github.com/CopilotKit/CopilotKit/blob/main/community/content/CONTRIBUTING.md).
+- For documentation-related contributions, [check out the documentation contributions guide](https://docs.copilotkit.ai/contributing/code-contributions).
 - Want to contribute but not sure how? [Join our Discord](https://discord.gg/6dffbvGU3D) and we'll help you out!
 
 > 💡 **NOTE:** All contributions must be submitted via a pull request and be reviewed by our team. This is to ensure that all contributions are of high quality and align with the project's goals.


### PR DESCRIPTION
…ontributions in the Readme.md

I edited the link under the contributing section ,  Code related contributions - to now redirect to where it is supposed to, which is - https://github.com/CopilotKit/CopilotKit/blob/main/community/content/CONTRIBUTING.md and
Documentation related contributions to -
https://docs.copilotkit.ai/contributing/code-contributions